### PR TITLE
i134 - corrected bullet point indentation

### DIFF
--- a/client-code/Stylesheet.html
+++ b/client-code/Stylesheet.html
@@ -101,6 +101,11 @@
     height: 1px;
   }
 
+  ul, ol {
+    padding: 0 0 0 15px;
+    margin: 0px;
+  }
+
   /********* Alerts and messages ********/
 
   .error-box {


### PR DESCRIPTION
Here is the state before:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/29384660/105649465-5647e100-5ea8-11eb-806a-460b9f883c28.png">

And after...

![image](https://user-images.githubusercontent.com/29384660/107092835-24b20c80-67fc-11eb-89a5-d6baac935c01.png)


