### PR TITLE
#189 - fixed projectList to data in the getAllFabLogs() method

### DIFF
--- a/server-code/Reports/Reports.ts
+++ b/server-code/Reports/Reports.ts
@@ -93,6 +93,6 @@ function getOpenChangeRequests() {
 */
 function getAllFabLogs() {
     var data = getSheetInfo(MAIN_SHEET_ID_STR, FAB_WELD_STR, DATA_STR);
-    transformToHyperLinks(projectList, ["Links"]);
+    transformToHyperLinks(data, ["Links"]);
     return buildTableHTML(data, getReportTableConfig());
 }


### PR DESCRIPTION
I fixed the incorrect usage of "projectList" as an input to transformToHTML in the getAllFabLogs() method.