### PR TITLE
i188 - Filtered data from fabrication sheet to remove empty rows

### DIFF
--- a/server-code/Reports/Reports.ts
+++ b/server-code/Reports/Reports.ts
@@ -93,6 +93,13 @@ function getOpenChangeRequests() {
 */
 function getAllFabLogs() {
     var data = getSheetInfo(MAIN_SHEET_ID_STR, FAB_WELD_STR, DATA_STR);
-    transformToHyperLinks(data, ["Links"]);
-    return buildTableHTML(data, getReportTableConfig());
+    var headers = data[0];
+    var filteredData = [headers];
+    for (var rowIdx = 1; rowIdx < data.length; rowIdx++) {
+        if (!(data[rowIdx][0] == "")) {
+            filteredData.push(data[rowIdx]);
+        }
+    }
+    transformToHyperLinks(filteredData, ["Links"]);
+    return buildTableHTML(filteredData, getReportTableConfig());
 }


### PR DESCRIPTION
I went ahead and implemented the code in the getAllFabLogs function and filtered the data directly there. This seemed to have been what was done in the other functions in the reports.ts file. If you would like me to make a separate removeBlank() function that would take in the data and return data without the blank rows, just let me know and I can make that change. Closes #188 